### PR TITLE
* Fix issue around use of SHA's instead of tags for ExternalProject_Add

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 venv.tar.gz
 build.venv
 venv
+venv.tar.gz
 
 # Prerequisites
 *.d

--- a/bootstrap_venv.sh
+++ b/bootstrap_venv.sh
@@ -2,17 +2,15 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR
 python3 -m venv venv
-. venv/bin/activate
+source venv/bin/activate
 pip install -U pip
 pip install -U wheel
 pip install -U cmake ninja
 
-mkdir -p build.venv
-cd build.venv
-cmake \
+cmake -B build.venv \
     -DFARM_NG_DEV_BUILD=On \
     -Dfarm_ng_INSTALL_PREFIX=$DIR/venv/prefix \
     -G Ninja \
     $DIR/.
 
-ninja -v
+cmake --build build.venv

--- a/cmake/External_cli11.cmake
+++ b/cmake/External_cli11.cmake
@@ -1,6 +1,6 @@
 ExternalProject_Add(cli11
   GIT_REPOSITORY  https://github.com/CLIUtils/CLI11
-  GIT_TAG a227cd10fc6dd2905965bafc2d3aa9cb9d910ce5
+  GIT_TAG v2.3.2
   GIT_SHALLOW ON
   PREFIX ${farm_ng_EXT_PREFIX}
   CMAKE_ARGS

--- a/cmake/External_expected.cmake
+++ b/cmake/External_expected.cmake
@@ -1,7 +1,7 @@
 ExternalProject_Add(expected
     GIT_REPOSITORY  "https://github.com/TartanLlama/expected.git"
     GIT_TAG "b74fecd4448a1a5549402d17ddc51e39faa5020c"
-    GIT_SHALLOW ON
+    GIT_SHALLOW OFF # Can't use this because we're using a SHA and not a branch
     PREFIX ${farm_ng_EXT_PREFIX}
     CMAKE_ARGS
     ${farm_ng_DEFAULT_ARGS}


### PR DESCRIPTION
see: https://gitlab.kitware.com/cmake/cmake/-/issues/17770 for discussion
* use source instead of execution to ensure venv is on path to favor pip installed cmake.
* Add tar to .gitignore to prevent accidental commit.