### PR TITLE
Add libglm-dev apt dependency

### DIFF
--- a/scripts/install_deps_ubuntu.sh
+++ b/scripts/install_deps_ubuntu.sh
@@ -24,6 +24,7 @@ sudo apt-get -y install \
      libcrypto++-dev \
      libegl1-mesa-dev \
      libglew-dev \
+     libglm-dev \
      libgoogle-glog-dev \
      libgtest-dev \
      libopencv-dev \


### PR DESCRIPTION
This dependency is used for CPU-based testing of GLSL shaders.